### PR TITLE
docs: add Cargo installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ brew tap defendend/ast-index
 brew install ast-index
 ```
 
+### Cargo (from Git)
+
+Requires a Rust toolchain.
+
+```bash
+cargo install --locked --git https://github.com/defendend/Claude-ast-index-search ast-index
+```
+
+This builds and installs the latest version from the default branch. For prebuilt release binaries, use Homebrew or Winget.
+
 ### Winget (Windows)
 
 ```shell


### PR DESCRIPTION
## Motivation

I wanted to install `ast-index` using Cargo, but the README did not mention that it can be installed directly from this Git repository.

This PR documents the existing Cargo installation method for users who do not use Homebrew.
It does not require publishing the package to crates.io.

## Testing

```bash
cargo install --locked --git https://github.com/defendend/Claude-ast-index-search ast-index
```
