### PR TITLE
Honor configured roots in universal search

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ ast-index deps app
 
 Use `ast-index update` after edits or branch switches. In monorepos with nested
 project markers, add `--walk-up` or `AST_INDEX_WALK_UP=1` to reuse the root
-index.
+index. Use `--root /path/to/project` (or `-C`) when the project root must not
+depend on the current directory.
 
 **Guides:** [User guide](USER_GUIDE.md) for everyday workflow;
 [Command setup guide](docs/setup-guide.md) for install/options/examples.
@@ -503,6 +504,11 @@ roots:
   - "../shared-lib"
   - "../common-modules"
 
+# Limit the primary root to these directories
+include:
+  - "app"
+  - "packages/shared"
+
 # Directories to exclude from indexing
 exclude:
   - "vendor"
@@ -514,6 +520,10 @@ no_ignore: false
 ```
 
 All fields are optional. CLI flags override config file values.
+
+Universal `search` scans the primary `include` scope and every configured root.
+Use `--local` to search only the primary scope or `--subtree NAME` to search one
+named additional root.
 
 ### Examples
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -93,13 +93,15 @@ ast-index rebuild
 ```
 
 For a large repository, add a project config so `rebuild`, `update`, and
-`watch` all scan the same intended paths:
+`watch`, and content search all scan the same intended paths:
 
 ```yaml
 # .ast-index.yaml
 include:
   - app
   - packages/shared
+roots:
+  - ../shared-library
 exclude:
   - vendor
   - generated
@@ -112,7 +114,11 @@ ast-index rebuild
 ```
 
 Use `include` when you only want selected directories from a larger tree. Use
-`exclude` for generated or vendored folders that should never enter the index.
+`roots` for additional source trees outside the primary root. Use `exclude` for
+generated or vendored folders that should never enter the index. Universal
+`search` scans the configured `include` paths and all additional roots by
+default; pass `--local` for the primary root only or `--subtree NAME` for one
+named additional root.
 
 ## Keeping The Index Fresh
 
@@ -227,6 +233,18 @@ ast-index --walk-up search "Payment"
 # or
 AST_INDEX_WALK_UP=1 ast-index search "Payment"
 ```
+
+To select one project root independently of the current directory, pass it
+explicitly. `--root` and `-C` also select that root's `.ast-index.yaml` and
+index cache:
+
+```bash
+ast-index --root /path/to/project search "Payment"
+ast-index -C /path/to/project update
+```
+
+An explicit root is mutually exclusive with `--walk-up` and disables automatic
+current-subdirectory result scoping.
 
 ## AI Agent Instructions
 

--- a/src/commands/index.rs
+++ b/src/commands/index.rs
@@ -8,9 +8,9 @@
 //! - hierarchy: Show class hierarchy
 //! - usages: Find symbol usages (indexed or grep-based)
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use colored::Colorize;
 use regex::Regex;
 use rusqlite::params;
@@ -34,6 +34,138 @@ fn auto_pattern_from_name<'a>(
         Some(n) if n.contains('*') || n.contains('?') => (None, Some(n)),
         _ => (name, pattern),
     }
+}
+
+#[derive(Debug)]
+struct ContentSearchRoot {
+    walk_root: PathBuf,
+    path_anchor: PathBuf,
+    root_key: String,
+}
+
+fn configured_path(primary: &Path, value: &str, label: &str) -> Result<PathBuf> {
+    ensure!(!value.trim().is_empty(), "{label} path must not be empty");
+    let raw = Path::new(value);
+    let candidate = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        primary.join(raw)
+    };
+    ensure!(
+        candidate.exists(),
+        "{label} path does not exist: {}",
+        candidate.display()
+    );
+    ensure!(
+        candidate.is_dir(),
+        "{label} path is not a directory: {}",
+        candidate.display()
+    );
+    Ok(db::safe_canonicalize(&candidate))
+}
+
+fn push_search_root(roots: &mut Vec<ContentSearchRoot>, candidate: ContentSearchRoot) {
+    if roots.iter().any(|existing| {
+        existing.root_key == candidate.root_key
+            && candidate.walk_root.starts_with(&existing.walk_root)
+    }) {
+        return;
+    }
+    roots.retain(|existing| {
+        existing.root_key != candidate.root_key
+            || !existing.walk_root.starts_with(&candidate.walk_root)
+    });
+    if !roots
+        .iter()
+        .any(|existing| existing.walk_root == candidate.walk_root)
+    {
+        roots.push(candidate);
+    }
+}
+
+fn content_search_roots(
+    root: &Path,
+    conn: &rusqlite::Connection,
+) -> Result<Vec<ContentSearchRoot>> {
+    let config = crate::indexer::load_config_strict(root)?.unwrap_or_default();
+    let primary = db::safe_canonicalize(root);
+    let primary_key = db::normalize_root_for_storage(&primary);
+    let local_only = std::env::var("AST_INDEX_LOCAL_SCOPE").is_ok();
+    let selected_subtree = std::env::var("AST_INDEX_SUBTREE").ok();
+    let mut roots = Vec::new();
+
+    let mut include_roots = Vec::new();
+    for include in config.include.unwrap_or_default() {
+        let path = configured_path(&primary, &include, "include")?;
+        ensure!(
+            path.starts_with(&primary),
+            "include path escapes the project root: {}",
+            include
+        );
+        include_roots.push(path);
+    }
+    if include_roots.is_empty() {
+        include_roots.push(primary.clone());
+    }
+    if selected_subtree.is_none() {
+        for walk_root in include_roots {
+            push_search_root(
+                &mut roots,
+                ContentSearchRoot {
+                    walk_root,
+                    path_anchor: primary.clone(),
+                    root_key: primary_key.clone(),
+                },
+            );
+        }
+    }
+
+    let subtrees = db::list_subtrees(conn)?;
+    let mut configured_extra_roots = Vec::new();
+    for configured_root in config.roots.unwrap_or_default() {
+        configured_extra_roots.push(configured_path(&primary, &configured_root, "extra root")?);
+    }
+
+    for subtree in &subtrees {
+        let path = configured_path(&primary, &subtree.canonical_path, "extra root")?;
+        let enabled = !local_only
+            && selected_subtree
+                .as_deref()
+                .map(|name| name == subtree.name)
+                .unwrap_or(true);
+        if enabled {
+            push_search_root(
+                &mut roots,
+                ContentSearchRoot {
+                    walk_root: path.clone(),
+                    path_anchor: path,
+                    root_key: subtree.canonical_path.clone(),
+                },
+            );
+        }
+    }
+
+    if !local_only && selected_subtree.is_none() {
+        for path in configured_extra_roots {
+            let root_key = db::normalize_root_for_storage(&path);
+            push_search_root(
+                &mut roots,
+                ContentSearchRoot {
+                    walk_root: path.clone(),
+                    path_anchor: path,
+                    root_key,
+                },
+            );
+        }
+    }
+
+    if let Some(name) = selected_subtree {
+        if !subtrees.iter().any(|subtree| subtree.name == name) {
+            return Ok(Vec::new());
+        }
+    }
+
+    Ok(roots)
 }
 
 /// Full-text search across files, symbols, and file contents
@@ -143,38 +275,41 @@ pub fn cmd_search(
         regex::escape(query)
     };
 
-    super::search_files_limited(
-        root,
-        &pattern,
-        &super::grep::ALL_SOURCE_EXTENSIONS,
-        limit,
-        |path, line_num, line| {
-            let rel_path = super::relative_path(root, path);
-            // Apply scope filter for grep results
-            if let Some(prefix) = scope.dir_prefix {
-                if !rel_path.starts_with(prefix) {
-                    return;
-                }
-            }
-            if let Some(in_file) = scope.in_file {
-                if !rel_path.contains(in_file) {
-                    return;
-                }
-            }
-            if let Some(module) = scope.module {
-                if !rel_path.starts_with(module) {
-                    return;
-                }
-            }
-            let content: String = line.trim().chars().take(100).collect();
-            let key = format!("{}:{}", rel_path, line_num);
-            if seen_content.insert(key) {
-                content_matches.push((rel_path, line_num, content));
-            }
-        },
-    )?;
-
     let resolver = PathResolver::try_from_conn(root, &conn)?;
+    for search_root in content_search_roots(root, &conn)? {
+        let remaining = limit.saturating_sub(content_matches.len());
+        if remaining == 0 {
+            break;
+        }
+        super::search_files_limited(
+            &search_root.walk_root,
+            &pattern,
+            &super::grep::ALL_SOURCE_EXTENSIONS,
+            remaining,
+            |path, line_num, line| {
+                let rel_path = super::relative_path(&search_root.path_anchor, path);
+                if scope
+                    .dir_prefix
+                    .is_some_and(|prefix| !rel_path.starts_with(prefix))
+                    || scope
+                        .in_file
+                        .is_some_and(|in_file| !rel_path.contains(in_file))
+                    || scope
+                        .module
+                        .is_some_and(|module| !rel_path.starts_with(module))
+                {
+                    return;
+                }
+                let resolved = resolver.resolve_with_root(&rel_path, Some(&search_root.root_key));
+                let content: String = line.trim().chars().take(100).collect();
+                let key = format!("{}:{}", path.display(), line_num);
+                if seen_content.insert(key) {
+                    content_matches.push((resolved, line_num, content));
+                }
+            },
+        )?;
+    }
+
     // Apply --subtree / --local filters before resolving paths so we don't
     // do extra work on rows the user will throw away.
     let files: Vec<String> = files
@@ -185,9 +320,6 @@ pub fn cmd_search(
     symbols.retain(|s| resolver.matches_filter(s.root_path.as_deref()));
     for s in &mut symbols {
         s.path = resolver.resolve_with_root(&s.path, s.root_path.as_deref());
-    }
-    for m in &mut content_matches {
-        m.0 = resolver.resolve(&m.0);
     }
 
     if format == "json" {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use rayon::prelude::*;
 use regex::Regex;
 use rusqlite::Connection;
@@ -217,6 +217,18 @@ pub struct ProjectConfig {
 /// Load project config from `.ast-index.yaml` or `.ast-index.yml` in the given root.
 /// Returns `None` if no config file found or on parse error (with warning).
 pub fn load_config(root: &Path) -> Option<ProjectConfig> {
+    match load_config_strict(root) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("Warning: {error:#}");
+            None
+        }
+    }
+}
+
+/// Load project config while preserving parse and read errors for commands
+/// that cannot safely fall back to scanning the whole project root.
+pub fn load_config_strict(root: &Path) -> Result<Option<ProjectConfig>> {
     let yaml_path = root.join(".ast-index.yaml");
     let yml_path = root.join(".ast-index.yml");
     let config_path = if yaml_path.exists() {
@@ -224,25 +236,15 @@ pub fn load_config(root: &Path) -> Option<ProjectConfig> {
     } else if yml_path.exists() {
         yml_path
     } else {
-        return None;
+        return Ok(None);
     };
 
-    match fs::read_to_string(&config_path) {
-        Ok(content) => match serde_yaml::from_str::<ProjectConfig>(&content) {
-            Ok(config) => {
-                eprintln!("Loaded config from {}", config_path.display());
-                Some(config)
-            }
-            Err(e) => {
-                eprintln!("Warning: failed to parse {}: {}", config_path.display(), e);
-                None
-            }
-        },
-        Err(e) => {
-            eprintln!("Warning: failed to read {}: {}", config_path.display(), e);
-            None
-        }
-    }
+    let content = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let config = serde_yaml::from_str::<ProjectConfig>(&content)
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+    eprintln!("Loaded config from {}", config_path.display());
+    Ok(Some(config))
 }
 
 /// Check if project has build system markers (Gradle/Maven build files)

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,17 @@ struct Cli {
     #[arg(long, global = true)]
     walk_up: bool,
 
+    /// Use this directory as the primary project root instead of discovering
+    /// it from the current directory. Also selects its config and index cache.
+    #[arg(
+        short = 'C',
+        long = "root",
+        global = true,
+        value_name = "PATH",
+        conflicts_with = "walk_up"
+    )]
+    root: Option<PathBuf>,
+
     /// Restrict search/listing commands to a single named subtree.
     /// Use `subtree list` to discover names. Conflicts with `--local`.
     /// May trim the result below `--limit` because the cap is applied to
@@ -811,6 +822,8 @@ fn main() -> Result<()> {
                 !t.is_empty() && t != "0" && !t.eq_ignore_ascii_case("false")
             })
             .unwrap_or(false);
+    let explicit_root = cli.root.as_deref().map(resolve_explicit_root).transpose()?;
+    let has_explicit_root = explicit_root.is_some();
     let cache_independent = matches!(
         &cli.command,
         Commands::Version
@@ -823,7 +836,18 @@ fn main() -> Result<()> {
     );
     let changed_command = matches!(&cli.command, Commands::Changed { .. });
     let release_command_publication = matches!(&cli.command, Commands::Watch);
-    let (root, mut command_cache_lease) = if changed_command {
+    let (root, mut command_cache_lease) = if let Some(root) = explicit_root {
+        let lease = if cache_independent
+            || matches!(
+                &cli.command,
+                Commands::Rebuild { .. } | Commands::Restore { .. } | Commands::Clear
+            ) {
+            None
+        } else {
+            db::acquire_project_lease_if_initialized(&root)?
+        };
+        (root, lease)
+    } else if changed_command {
         // `changed` discovers only VCS markers from the invocation directory.
         // It must never probe or create the ast-index cache.
         (std::env::current_dir()?, None)
@@ -859,7 +883,7 @@ fn main() -> Result<()> {
 
     // Compute directory scope: if cwd is inside project root, limit search to cwd subtree
     let cwd = std::env::current_dir().unwrap_or_default();
-    let dir_prefix = if cwd != root {
+    let dir_prefix = if !has_explicit_root && cwd != root {
         cwd.strip_prefix(&root).ok().map(|rel| {
             let mut s = rel.to_string_lossy().to_string();
             if !s.ends_with('/') {
@@ -1694,6 +1718,25 @@ fn shell_quote(arg: &str) -> String {
 
 fn find_project_root_for_write() -> Result<PathBuf> {
     Ok(std::env::current_dir()?)
+}
+
+fn resolve_explicit_root(path: &Path) -> Result<PathBuf> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    anyhow::ensure!(
+        candidate.exists(),
+        "project root does not exist: {}",
+        candidate.display()
+    );
+    anyhow::ensure!(
+        candidate.is_dir(),
+        "project root is not a directory: {}",
+        candidate.display()
+    );
+    Ok(db::safe_canonicalize(&candidate))
 }
 
 /// After a successful rebuild/update, sweep index caches for other projects

--- a/tests/search_scope_cli_tests.rs
+++ b/tests/search_scope_cli_tests.rs
@@ -1,0 +1,205 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn binary() -> &'static Path {
+    Path::new(env!("CARGO_BIN_EXE_ast-index"))
+}
+
+fn write(path: &Path, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+fn run(cwd: &Path, cache: &Path, args: &[&str]) -> Output {
+    Command::new(binary())
+        .current_dir(cwd)
+        .args(args)
+        .env("AST_INDEX_CACHE_DIR", cache)
+        .env("AST_INDEX_DISABLE_GC", "1")
+        .env_remove("AST_INDEX_DB_PATH")
+        .env_remove("KOTLIN_INDEX_DB_PATH")
+        .env_remove("AST_INDEX_MAX_FILES")
+        .output()
+        .unwrap()
+}
+
+fn content_paths(output: &Output) -> Vec<String> {
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).unwrap();
+    json["content_matches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["path"].as_str().unwrap().to_string())
+        .collect()
+}
+
+struct Workspace {
+    _tmp: TempDir,
+    project: PathBuf,
+    caller: PathBuf,
+    cache: PathBuf,
+}
+
+fn workspace() -> Workspace {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path().join("project");
+    let extra = tmp.path().join("extra");
+    let caller = tmp.path().join("caller");
+    let cache = tmp.path().join("cache");
+
+    write(
+        &project.join("Cargo.toml"),
+        "[package]\nname = \"search-scope\"\nversion = \"0.1.0\"\n",
+    );
+    write(
+        &project.join(".ast-index.yaml"),
+        "include:\n  - included\nroots:\n  - ../extra\n",
+    );
+    write(
+        &project.join("included/main.rs"),
+        "fn primary() { let _ = \"scope_sentinel\"; }\n",
+    );
+    write(
+        &project.join("excluded/ignored.rs"),
+        "fn excluded() { let _ = \"scope_sentinel\"; }\n",
+    );
+    write(
+        &extra.join("lib.rs"),
+        "fn extra() { let _ = \"scope_sentinel\"; }\n",
+    );
+    fs::create_dir_all(&caller).unwrap();
+
+    let project_arg = project.to_str().unwrap();
+    let rebuild = run(&caller, &cache, &["--root", project_arg, "rebuild"]);
+    assert!(
+        rebuild.status.success(),
+        "rebuild failed: {}",
+        String::from_utf8_lossy(&rebuild.stderr)
+    );
+
+    Workspace {
+        _tmp: tmp,
+        project,
+        caller,
+        cache,
+    }
+}
+
+#[test]
+fn search_honors_include_and_searches_configured_roots() {
+    let workspace = workspace();
+    let project = workspace.project.to_str().unwrap();
+    let output = run(
+        &workspace.caller,
+        &workspace.cache,
+        &[
+            "--root",
+            project,
+            "--format",
+            "json",
+            "search",
+            "scope_sentinel",
+        ],
+    );
+    let paths = content_paths(&output);
+
+    assert_eq!(paths.len(), 2, "unexpected content matches: {paths:?}");
+    assert!(paths.iter().any(|path| path.contains("included/main.rs")));
+    assert!(paths.iter().any(|path| path.contains("extra/lib.rs")));
+    assert!(!paths.iter().any(|path| path.contains("excluded")));
+}
+
+#[test]
+fn local_and_subtree_flags_limit_content_search_roots() {
+    let workspace = workspace();
+    let project = workspace.project.to_str().unwrap();
+
+    let local = run(
+        &workspace.caller,
+        &workspace.cache,
+        &[
+            "-C",
+            project,
+            "--local",
+            "--format",
+            "json",
+            "search",
+            "scope_sentinel",
+        ],
+    );
+    let local_paths = content_paths(&local);
+    assert_eq!(
+        local_paths.len(),
+        1,
+        "unexpected local matches: {local_paths:?}"
+    );
+    assert!(local_paths[0].contains("included/main.rs"));
+
+    let subtree = run(
+        &workspace.caller,
+        &workspace.cache,
+        &[
+            "--root",
+            project,
+            "--subtree",
+            "extra",
+            "--format",
+            "json",
+            "search",
+            "scope_sentinel",
+        ],
+    );
+    let subtree_paths = content_paths(&subtree);
+    assert_eq!(
+        subtree_paths.len(),
+        1,
+        "unexpected subtree matches: {subtree_paths:?}"
+    );
+    assert!(subtree_paths[0].contains("extra/lib.rs"));
+}
+
+#[test]
+fn search_rejects_invalid_scope_before_walking() {
+    let workspace = workspace();
+    write(
+        &workspace.project.join(".ast-index.yaml"),
+        "include:\n  - missing\n",
+    );
+    let project = workspace.project.to_str().unwrap();
+    let output = run(
+        &workspace.caller,
+        &workspace.cache,
+        &["--root", project, "search", "scope_sentinel"],
+    );
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("include path does not exist"), "{stderr}");
+}
+
+#[test]
+fn explicit_root_rejects_missing_directory() {
+    let tmp = TempDir::new().unwrap();
+    let missing = tmp.path().join("missing");
+    let cache = tmp.path().join("cache");
+    let output = run(
+        tmp.path(),
+        &cache,
+        &["--root", missing.to_str().unwrap(), "stats"],
+    );
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("project root does not exist"), "{stderr}");
+}


### PR DESCRIPTION
## Summary

- add global `--root PATH` / `-C PATH` options to select the primary root, config, and cache independently of the current directory
- make universal search content scanning honor the primary `include` allow-list and configured or indexed additional roots
- apply `--local` and `--subtree NAME` before filesystem traversal
- validate configured paths early and deduplicate overlapping include paths
- document the new root and search-scope behavior

## Motivation

A project may intentionally keep its primary root at a large monorepo boundary while restricting indexed content with `include` and attaching several additional source roots. Index-backed search already used the indexed workspace, but the content-search phase walked only the primary root. That could scan far outside the configured allow-list and omit content from additional roots.

## Verification

- `cargo build --release --workspace`
- `cargo test --test search_scope_cli_tests --test subtree_filter_tests --test update_extra_roots_tests`
- release workspace tests passed with one pre-existing environment-sensitive VCS marker test excluded
- `scripts/smoke.sh`: 6/6 scenarios passed
- `scripts/validate-agent-plugins.sh`