### PR TITLE
cpp: index functions that return a pointer or a reference

### DIFF
--- a/src/parsers/treesitter/cpp.rs
+++ b/src/parsers/treesitter/cpp.rs
@@ -908,6 +908,73 @@ fn find_capture<'a>(
 mod tests {
     use super::*;
 
+    // --- Functions returning a pointer or a reference ---
+
+    #[test]
+    fn test_parse_pointer_and_reference_return_functions() {
+        let content = r#"
+GridMap* TerrainInfo::GetGrid(uint32 mapId, float x, float y, bool loadIfMissing /*= true*/)
+{
+    return nullptr;
+}
+
+Creature* Player::GetNPCIfCanInteractWith(ObjectGuid const& guid, NPCFlags npcFlags) const
+{
+    return nullptr;
+}
+
+PhaseShift const& PhasingHandler::GetEmptyPhaseShift()
+{
+    static PhaseShift const empty;
+    return empty;
+}
+
+Player* FindPlayer(ObjectGuid const& guid)
+{
+    return nullptr;
+}
+
+char** SplitArgs(char const* line)
+{
+    return nullptr;
+}
+
+Color4& Color4::operator=(Color4 const& other)
+{
+    return *this;
+}
+
+template <class T>
+T* MakeOne()
+{
+    return nullptr;
+}
+
+uint32 Plain()
+{
+    return 0;
+}
+"#;
+        let symbols = CPP_PARSER.parse_symbols(content).unwrap();
+        for name in ["GetGrid", "GetNPCIfCanInteractWith", "GetEmptyPhaseShift", "FindPlayer", "SplitArgs", "operator=", "MakeOne", "Plain"] {
+            let found: Vec<_> = symbols.iter().filter(|s| s.name == name).collect();
+            assert_eq!(found.len(), 1, "Expected exactly one symbol named {}, got: {:?}", name, symbols);
+            assert_eq!(found[0].kind, SymbolKind::Function, "{} should be a function", name);
+        }
+        let get_grid = symbols.iter().find(|s| s.name == "GetGrid").unwrap();
+        assert!(
+            get_grid.parents.iter().any(|(p, _)| p == "TerrainInfo"),
+            "Expected GetGrid to belong to TerrainInfo, got: {:?}",
+            get_grid.parents
+        );
+        let assign = symbols.iter().find(|s| s.name == "operator=").unwrap();
+        assert!(
+            assign.parents.iter().any(|(p, _)| p == "Color4"),
+            "Expected operator= to belong to Color4, got: {:?}",
+            assign.parents
+        );
+    }
+
     // --- Classes ---
 
     #[test]

--- a/src/parsers/treesitter/queries/cpp.scm
+++ b/src/parsers/treesitter/queries/cpp.scm
@@ -100,3 +100,71 @@
 ; #include <path> or #include "path"
 (preproc_include
   path: (_) @include_path)
+
+; === Functions whose return type is a pointer or a reference (added 2026-09-04) ===
+; tree-sitter-cpp wraps the function_declarator of `T* f()` in a pointer_declarator and of
+; `T& f()` in a reference_declarator, so the patterns above never matched them: every
+; Creature*/GameObject*/GridMap*-returning function of a TrinityCore checkout was missing from
+; the index (measured six for six). Same captures as above. No template_declaration variants:
+; the plain function_definition patterns already match a definition inside a template, and a
+; second pattern would only duplicate it (Codex, 2026-09-04). scope: (_) so that
+; Outer::Inner::f and Class<X>::f (template_type scope) are caught as well.
+
+; T* f(...)
+(function_definition
+  declarator: (pointer_declarator
+    declarator: (function_declarator
+      declarator: (identifier) @func_name)))
+
+; T** f(...)
+(function_definition
+  declarator: (pointer_declarator
+    declarator: (pointer_declarator
+      declarator: (function_declarator
+        declarator: (identifier) @func_name))))
+
+; T& f(...)
+(function_definition
+  declarator: (reference_declarator
+    (function_declarator
+      declarator: (identifier) @func_name)))
+
+; T* Class::Method(...)
+(function_definition
+  declarator: (pointer_declarator
+    declarator: (function_declarator
+      declarator: (qualified_identifier
+        scope: (_) @method_class
+        name: (identifier) @method_name))))
+
+; T** Class::Method(...)
+(function_definition
+  declarator: (pointer_declarator
+    declarator: (pointer_declarator
+      declarator: (function_declarator
+        declarator: (qualified_identifier
+          scope: (_) @method_class
+          name: (identifier) @method_name)))))
+
+; T& Class::Method(...)
+(function_definition
+  declarator: (reference_declarator
+    (function_declarator
+      declarator: (qualified_identifier
+        scope: (_) @method_class
+        name: (identifier) @method_name))))
+
+; T* Class::operator...(...) and T& Class::operator...(...)
+(function_definition
+  declarator: (pointer_declarator
+    declarator: (function_declarator
+      declarator: (qualified_identifier
+        scope: (_) @method_class
+        name: (operator_name) @method_name))))
+
+(function_definition
+  declarator: (reference_declarator
+    (function_declarator
+      declarator: (qualified_identifier
+        scope: (_) @method_class
+        name: (operator_name) @method_name))))


### PR DESCRIPTION
## C++: index functions that return a pointer or a reference

`queries/cpp.scm` names a function only through `function_definition → function_declarator`.
tree-sitter-cpp wraps the declarator of `T* f()` in a `pointer_declarator` and of `T& f()` in a
`reference_declarator`, so every function whose return type is a pointer or a reference was
silently absent from the index — free functions and out-of-class method definitions alike.

Measured on a TrinityCore checkout (2 900 files): `Creature* Player::GetNPCIfCanInteractWith`,
`GridMap* TerrainInfo::GetGrid`, `Player* ObjectAccessor::FindPlayer`, `PhaseShift const&
PhasingHandler::GetEmptyPhaseShift` and every similar definition answered "No symbols found"
while `uint32 TerrainInfo::GetAreaId` next to them was listed. With this change the index grew
from 192 636 to 200 856 symbols; all of them resolve with `file:line`; `operator=` /
`operator[]` definitions are listed too.

### What the patch does

Eight patterns appended to `src/parsers/treesitter/queries/cpp.scm`, reusing the existing
captures (`func_name`, `method_class` / `method_name`), so `cpp.rs` needs no change:

- `T* f()`, `T** f()`, `T& f()` — free functions;
- `T* Class::f()`, `T** Class::f()`, `T& Class::f()` — out-of-class definitions, with
  `scope: (_)` so nested (`A::B::f`) and template (`Class<X>::f`) scopes match;
- `T* Class::operator…()` / `T& Class::operator…()` via `operator_name`.

No `template_declaration` variants: the plain `function_definition` patterns already match a
definition inside a template, and a second pattern would emit the symbol twice (the handler does
not deduplicate). `reference_declarator` is matched positionally because the grammar
(tree-sitter-cpp 0.23.4, `node-types.json`) gives it no `declarator` field; `pointer_declarator`
has one.

Not covered, on purpose (separate work): in-class inline definitions (`field_identifier`, which
the query never indexed for any return type), pointers deeper than two levels, trailing return
types.

<details><summary><strong>Русский</strong></summary>

Запрос `cpp.scm` находил функцию только по цепочке `function_definition → function_declarator`, а
у `T* f()` и `T& f()` между ними стоит `pointer_declarator` / `reference_declarator`, поэтому все
функции, возвращающие указатель или ссылку, в индекс не попадали. Замер на TrinityCore: 192 636 →
200 856 символов, все пропавшие функции находятся. Восемь шаблонов в `cpp.scm`, те же захваты, код
на Rust не тронут. Без вариантов для `template_declaration` (дублировали бы символы); `scope: (_)`
для вложенных и шаблонных областей; операторы через `operator_name`.

</details>
