### PR TITLE
Fix reference indexing: upper-snake constants, vendor .d.ts noise, same-file usages

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -4583,7 +4583,10 @@ fn parse_dts_file(file_path: &Path, rel_path: &str, root_path: &str) -> Result<P
     }
 
     let content = fs::read_to_string(file_path)?;
-    let (symbols, refs) = parsers::parse_file_symbols(&content, parsers::FileType::TypeScript)?;
+    // Symbols only: a .d.ts is indexed so that a library's exported types resolve,
+    // and its internal references would otherwise dominate `usages`/`refs` output
+    // for common names, pushing the project's own code past the result limit.
+    let symbols = parsers::parse_file_symbols_only(&content, parsers::FileType::TypeScript)?;
 
     Ok(ParsedFile {
         rel_path: rel_path.to_string(),
@@ -4592,7 +4595,7 @@ fn parse_dts_file(file_path: &Path, rel_path: &str, root_path: &str) -> Result<P
         size,
         symbols,
         qualified_names: HashMap::new(),
-        refs,
+        refs: Vec::new(),
     })
 }
 

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -700,6 +700,41 @@ pub fn parse_file_symbols(
     Ok((symbols, refs))
 }
 
+/// Parse only the symbols of a file, skipping reference extraction.
+///
+/// Used for inputs indexed purely for their definitions — `node_modules` type
+/// declarations — where references would describe a library's own internals.
+pub fn parse_file_symbols_only(content: &str, file_type: FileType) -> Result<Vec<ParsedSymbol>> {
+    let effective_type = if file_type == FileType::Cpp && detect_h_file_objc(content) {
+        FileType::ObjC
+    } else {
+        file_type
+    };
+
+    if let Some(ts_parser) = treesitter::get_treesitter_parser(effective_type) {
+        return ts_parser.parse_symbols(content);
+    }
+
+    let stripped = strip_comments(content, file_type);
+    let content = &stripped;
+
+    match file_type {
+        FileType::Perl => parse_perl_symbols(content),
+        FileType::Wsdl => parse_wsdl_symbols(content),
+        FileType::Vue => {
+            let script = extract_vue_script(content);
+            let script_stripped = strip_c_comments(&script, false);
+            parse_typescript_symbols(&script_stripped)
+        }
+        FileType::Svelte => {
+            let script = extract_svelte_script(content);
+            let script_stripped = strip_c_comments(&script, false);
+            parse_typescript_symbols(&script_stripped)
+        }
+        _ => Err(anyhow::anyhow!("No parser for {:?}", file_type)),
+    }
+}
+
 /// Extract references/usages from file content
 pub fn extract_references(
     content: &str,
@@ -1050,6 +1085,18 @@ mod tests {
         let refs = extract_references(content, &symbols).unwrap();
         assert!(refs.iter().any(|r| r.name == "PaymentRepository"));
         assert!(refs.iter().any(|r| r.name == "PaymentRepositoryImpl"));
+    }
+
+    #[test]
+    fn test_parse_file_symbols_only_skips_refs() {
+        let content = "export declare const RESULT_TONE: Record<string, string>;\nexport declare function helper(): void;\n";
+        let symbols = parse_file_symbols_only(content, FileType::TypeScript).unwrap();
+        assert!(symbols.iter().any(|s| s.name == "RESULT_TONE"));
+        // Same input through the full entry point still yields references, so the
+        // difference is the skipped extraction, not a parser change.
+        let (full_symbols, refs) = parse_file_symbols(content, FileType::TypeScript).unwrap();
+        assert_eq!(symbols.len(), full_symbols.len());
+        assert!(!refs.is_empty());
     }
 
     #[test]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -721,9 +721,14 @@ pub fn extract_references_for_lang(
 
     // Regex for identifiers that might be references:
     // - CamelCase identifiers (types, classes) like PaymentRepository, String
+    // - SCREAMING_SNAKE_CASE constants like DEAL_KIND_ICONS, MAX_RETRIES
     // - Function calls like getCards(, process(
+    //
+    // `_` is a word character, so `\b` never fires inside DEAL_KIND_ICONS: without
+    // `_` in the class the name matches neither whole nor in parts, and every
+    // reference to an upper-snake constant is silently dropped.
     static IDENTIFIER_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"\b([A-Z][a-zA-Z0-9]*)\b").unwrap());
+        LazyLock::new(|| Regex::new(r"\b([A-Z][A-Za-z0-9_]*)\b").unwrap());
 
     let identifier_re = &*IDENTIFIER_RE; // CamelCase types
     static FUNC_CALL_RE: LazyLock<Regex> =
@@ -1045,6 +1050,28 @@ mod tests {
         let refs = extract_references(content, &symbols).unwrap();
         assert!(refs.iter().any(|r| r.name == "PaymentRepository"));
         assert!(refs.iter().any(|r| r.name == "PaymentRepositoryImpl"));
+    }
+
+    #[test]
+    fn test_extract_references_finds_upper_snake_case_constants() {
+        // `_` is a word character, so a `[A-Z][a-zA-Z0-9]*` class matches an
+        // upper-snake name neither whole nor in parts (issue: `usages` returned
+        // zero for every SCREAMING_SNAKE constant).
+        let content = "const icon = DEAL_KIND_ICONS[kind]\nuseMediaQuery(COARSE_POINTER_MQ)\n";
+        let symbols = vec![];
+        let refs = extract_references(content, &symbols).unwrap();
+        assert!(
+            refs.iter().any(|r| r.name == "DEAL_KIND_ICONS"),
+            "expected DEAL_KIND_ICONS; got {:?}",
+            refs.iter().map(|r| &r.name).collect::<Vec<_>>()
+        );
+        assert!(
+            refs.iter().any(|r| r.name == "COARSE_POINTER_MQ"),
+            "expected COARSE_POINTER_MQ; got {:?}",
+            refs.iter().map(|r| &r.name).collect::<Vec<_>>()
+        );
+        // The name must not be split into fragments.
+        assert!(!refs.iter().any(|r| r.name == "DEAL" || r.name == "ICONS"));
     }
 
     #[test]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -77,7 +77,7 @@ fn truncate_to_len(s: &str, max: usize) -> String {
 
 use anyhow::Result;
 use regex::Regex;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 
 /// Strip // line comments only (no block comments). Used for BSL.
@@ -751,8 +751,19 @@ pub fn extract_references_for_lang(
 ) -> Result<Vec<ParsedRef>> {
     let mut refs = Vec::new();
 
-    // Build set of locally defined symbol names (to skip them)
-    let defined_names: HashSet<&str> = defined_symbols.iter().map(|s| s.name.as_str()).collect();
+    // Map every locally defined symbol to the line it is declared on. Only that
+    // line is skipped: a symbol used further down its own file (a constant fed
+    // into the next constant, a local interface passed to defineProps) is a real
+    // usage, and skipping the whole name hid it from `usages` entirely.
+    let mut declared_at: HashMap<&str, HashSet<usize>> = HashMap::new();
+    for symbol in defined_symbols {
+        declared_at
+            .entry(symbol.name.as_str())
+            .or_default()
+            .insert(symbol.line);
+    }
+    let is_declaration_line =
+        |name: &str, line: usize| declared_at.get(name).is_some_and(|l| l.contains(&line));
 
     // Regex for identifiers that might be references:
     // - CamelCase identifiers (types, classes) like PaymentRepository, String
@@ -979,7 +990,7 @@ pub fn extract_references_for_lang(
             if !name.is_empty()
                 && !base_keywords.contains(name)
                 && !extra_keywords.contains(name)
-                && !defined_names.contains(name)
+                && !is_declaration_line(name, line_num)
             {
                 refs.push(ParsedRef {
                     name: name.to_string(),
@@ -995,7 +1006,7 @@ pub fn extract_references_for_lang(
             if !name.is_empty()
                 && !base_keywords.contains(name)
                 && !extra_keywords.contains(name)
-                && !defined_names.contains(name)
+                && !is_declaration_line(name, line_num)
             {
                 // Only add if name length > 2 to avoid noise
                 if name.len() > 2 {
@@ -1085,6 +1096,28 @@ mod tests {
         let refs = extract_references(content, &symbols).unwrap();
         assert!(refs.iter().any(|r| r.name == "PaymentRepository"));
         assert!(refs.iter().any(|r| r.name == "PaymentRepositoryImpl"));
+    }
+
+    #[test]
+    fn test_extract_references_finds_usage_in_declaring_file() {
+        // A symbol used further down its own file is a real usage; skipping the
+        // whole name (instead of just the declaration line) hid it from `usages`.
+        let content = "export const ICONS = {}\nexport const ORDER = Object.keys(ICONS)\n";
+        let symbols = vec![ParsedSymbol {
+            name: "ICONS".to_string(),
+            kind: SymbolKind::Constant,
+            line: 1,
+            signature: "export const ICONS".to_string(),
+            parents: vec![],
+        }];
+        let refs = extract_references(content, &symbols).unwrap();
+        assert!(
+            refs.iter().any(|r| r.name == "ICONS" && r.line == 2),
+            "expected ICONS usage on line 2; got {:?}",
+            refs.iter().map(|r| (&r.name, r.line)).collect::<Vec<_>>()
+        );
+        // The declaration itself is still not a reference.
+        assert!(!refs.iter().any(|r| r.name == "ICONS" && r.line == 1));
     }
 
     #[test]


### PR DESCRIPTION
Three related fixes to reference indexing, found while auditing dead code in a Vue 3 + TypeScript + Rails project (~1400 source files, 5469 `.d.ts` in `node_modules`). Each commit stands alone and carries a regression test.

## 1. References to `SCREAMING_SNAKE_CASE` constants were never indexed

`_` is a word character, so `\b` never fires inside `DEAL_KIND_ICONS`. With the `[A-Z][a-zA-Z0-9]*` class the name matched neither as a whole nor in fragments, and every reference to an upper-snake constant was dropped — `symbol` found the declaration while `usages` and `refs` reported zero. Verified directly in SQLite: no such name existed in the `refs` table at all.

Allowing `_` inside the class makes these constants resolve like any other identifier.

## 2. `.d.ts` files contributed their internal references

Type declarations are indexed to resolve a library's exported symbols, but `parse_dts_file` also stored references found inside them — **71% of all refs** in the test project. On common names those internals crowded out the project's own code:

| `usages` | before | after |
|---|---|---|
| `Ref` | 300 (hit the limit, almost all vendor) | 38, all local |
| `Component` | 127 (89 vendor) | 38, all local |
| `Props` | 74 (100% vendor) | 2, both local |

A new `parse_file_symbols_only` skips reference extraction for these inputs. Library types stay fully resolvable — `symbols` is unchanged at 70283, of which 53976 still come from `node_modules`.

## 3. Usages inside the declaring file were skipped

`extract_references_for_lang` skipped a locally defined name *everywhere* in its own file rather than only on its declaration line. A constant feeding the next constant, or a local interface passed to `defineProps`, never showed up in `usages`, so impact analysis silently missed every same-file consumer.

Scoping the skip to the declaration line restores those usages while keeping the declaration itself out of the results. Line numbers align across all parsing paths: `extract_vue_script` pads the template with blank lines and `strip_c_comments` replaces comments with spaces, so both preserve the original numbering.

## Measurements

Same project, full rebuild, before → after all three:

```
refs         251925 -> 76397   (-70%)
symbols       70283 -> 70283   (unchanged)
database     52 MB  -> 27 MB   (-48%)
index CPU     8.6 s -> 6.5 s
```

Per-symbol, `usages` counts:

| symbol | before | after |
|---|---|---|
| `RESULT_TONE` | 0 | 11 |
| `MD_MQ` | 0 | 7 |
| `COARSE_POINTER_MQ` | 0 | 5 |
| `RECORD_FORM_DIALOGS` | 0 | 4 |
| `DEAL_KIND_ICONS` | 0 | 2 |

Correctness checks on the resulting index:

- no previously indexed name disappeared, and no existing name changed its reference count after commit 1 (0 of 24958);
- only 3 of 5660 same-file references land on a declaration line, and all three are `export default defineConfig({` in `vite`/`vitest`/`playwright` configs, where the parser registers the imported call as a symbol — the reference itself is a genuine call;
- `cargo test`: 988 passed, 0 failed.

`cargo fmt` reports pre-existing diffs in `src/parsers/treesitter/cpp.rs`, `tests/memory_protection_tests.rs` and `tests/sub_projects_android_resources_tests.rs`; they are present on `main` and untouched here.

## Relation to #65

#65 reports the same symptom — `usages` returning zero — for lowerCamelCase constants produced by factory calls, where the declaration never reaches the symbol index. That path is not addressed here: a bare lowercase identifier is only matched when followed by `(`, so it needs its own fix. Commit 1 covers the upper-snake case, where the symbol *is* indexed but its references are not.
